### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/barcode_reader_nodelet.cpp
+++ b/src/barcode_reader_nodelet.cpp
@@ -134,4 +134,4 @@ namespace zbar_ros
   }
 }  // namespace zbar_ros
 
-PLUGINLIB_DECLARE_CLASS(zbar_ros, BarcodeReaderNodelet, zbar_ros::BarcodeReaderNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(zbar_ros::BarcodeReaderNodelet, nodelet::Nodelet);


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions