### PR TITLE
Update tooling-ci.yaml

### DIFF
--- a/.github/workflows/tooling-ci.yaml
+++ b/.github/workflows/tooling-ci.yaml
@@ -12,13 +12,14 @@ jobs:
             distro: foxy
           - os: ubuntu-20.04
             distro: galactic
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+            distro: humble
+          - os: ubuntu-22.04
             distro: rolling
     steps:
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/setup-ros@v0.3
         with:
           required-ros-distributions: ${{ matrix.distro }}
       - uses: ros-tooling/action-ros-ci@v0.2
         with:
-          package-name: zbar_ros
           target-ros2-distro: ${{ matrix.distro }}


### PR DESCRIPTION
- Adds Humble 22.04 and Rolling 22.04 CI
- Bump to newer setup-ros @0.3
- Package name is not needed, as it will build all packages by default.