### PR TITLE
Fix deprecated cv_bridge header file

### DIFF
--- a/src/barcode_reader_node.cpp
+++ b/src/barcode_reader_node.cpp
@@ -32,7 +32,7 @@
 #include <functional>
 #include <chrono>
 #include "zbar_ros/barcode_reader_node.hpp"
-#include "cv_bridge/cv_bridge.h"
+#include "cv_bridge/cv_bridge.hpp"
 
 using namespace std::chrono_literals;
 


### PR DESCRIPTION
Fixes:

```sh
CMakeFiles/barcode_reader_node.dir/src/barcode_reader_node.cpp.o
In file included from /workspaces/dev_containers_ros2/rolling/rolling-desktop-full/zbar_ros_ws/src/zbar_ros/src/barcode_reader_node.cpp:35:
/opt/ros/rolling/include/cv_bridge/cv_bridge/cv_bridge.h:42:2: warning: #warning This header is obsolete, please include cv_bridge/cv_bridge.hpp instead [-Wcpp]
   42 | #warning This header is obsolete, please include cv_bridge/cv_bridge.hpp instead
      |  ^~~~~~~
```