### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/zbar_ros/CMakeLists.txt
+++ b/zbar_ros/CMakeLists.txt
@@ -29,13 +29,14 @@ include_directories(
 # Build library
 add_library(barcode_reader_node src/barcode_reader_node.cpp)
 target_link_libraries(barcode_reader_node PUBLIC
-  rclcpp
-  sensor_msgs
-  std_msgs
-  cv_bridge
-  zbar_ros_interfaces
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  ${zbar_ros_interfaces_TARGETS}
+  cv_bridge::cv_bridge
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
+  zbar
 )
-target_link_libraries(barcode_reader_node zbar)
 
 # Build executable
 add_executable(barcode_reader src/barcode_reader_main.cpp)

--- a/zbar_ros/CMakeLists.txt
+++ b/zbar_ros/CMakeLists.txt
@@ -28,12 +28,13 @@ include_directories(
 
 # Build library
 add_library(barcode_reader_node src/barcode_reader_node.cpp)
-ament_target_dependencies(barcode_reader_node
+target_link_libraries(barcode_reader_node PUBLIC
   rclcpp
   sensor_msgs
   std_msgs
   cv_bridge
-  zbar_ros_interfaces)
+  zbar_ros_interfaces
+)
 target_link_libraries(barcode_reader_node zbar)
 
 # Build executable


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
