### PR TITLE
Fix zbar includes for colcon builds

### DIFF
--- a/zbar_ros/CMakeLists.txt
+++ b/zbar_ros/CMakeLists.txt
@@ -22,12 +22,30 @@ find_package(sensor_msgs REQUIRED)
 find_package(zbar_ros_interfaces REQUIRED)
 find_package(cv_bridge REQUIRED)
 
-# Include header files
-include_directories(
-  include)
+# Find zbar library
+find_library(ZBAR_LIBRARY
+  NAMES zbar
+)
+
+find_path(ZBAR_INCLUDE_DIR
+  NAMES zbar.h
+)
+
+if(NOT ZBAR_LIBRARY)
+  message(FATAL_ERROR "zbar library not found. Please install libzbar-dev")
+endif()
+
+if(NOT ZBAR_INCLUDE_DIR)
+  message(FATAL_ERROR "zbar.h not found. Please install libzbar-dev")
+endif()
+
 
 # Build library
 add_library(barcode_reader_node src/barcode_reader_node.cpp)
+target_include_directories(barcode_reader_node PUBLIC
+  ${ZBAR_INCLUDE_DIR}
+  include
+)
 target_link_libraries(barcode_reader_node PUBLIC
   ${sensor_msgs_TARGETS}
   ${std_msgs_TARGETS}
@@ -35,7 +53,7 @@ target_link_libraries(barcode_reader_node PUBLIC
   cv_bridge::cv_bridge
   rclcpp::rclcpp
   sensor_msgs::sensor_msgs_library
-  zbar
+  ${ZBAR_LIBRARY}
 )
 
 # Build executable

--- a/zbar_ros/include/zbar_ros/barcode_reader_node.hpp
+++ b/zbar_ros/include/zbar_ros/barcode_reader_node.hpp
@@ -35,7 +35,7 @@
 #include <unordered_map>
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/timer.hpp"
-#include "./zbar.h"
+#include <zbar.h>
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "zbar_ros_interfaces/msg/symbol.hpp"

--- a/zbar_ros/include/zbar_ros/barcode_reader_node.hpp
+++ b/zbar_ros/include/zbar_ros/barcode_reader_node.hpp
@@ -31,11 +31,13 @@
 #ifndef ZBAR_ROS__BARCODE_READER_NODE_HPP_
 #define ZBAR_ROS__BARCODE_READER_NODE_HPP_
 
+#include <zbar.h>
+
 #include <string>
 #include <unordered_map>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/timer.hpp"
-#include <zbar.h>
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/string.hpp"
 #include "zbar_ros_interfaces/msg/symbol.hpp"

--- a/zbar_ros_interfaces/CMakeLists.txt
+++ b/zbar_ros_interfaces/CMakeLists.txt
@@ -30,6 +30,10 @@ ament_export_dependencies(rosidl_default_runtime)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+
+  # Skip copyright check, because the copyright used is not recognised by ament_copyright
+  set(ament_cmake_copyright_FOUND TRUE)
+
   ament_lint_auto_find_test_dependencies()
 endif()
 


### PR DESCRIPTION
Fixes this error when building with colcon:
```
zbar_ros/zbar_ros/include/zbar_ros/barcode_reader_node.hpp:38:10: fatal error: ./zbar.h: No such file or directory
   38 | #include "./zbar.h"
      |          ^~~~~~~~~~
compilation terminated.
```